### PR TITLE
Add support for cinnamon menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,19 @@ CFLAGS = -g -Wall
 CFLAGS += `pkg-config --cflags glib-2.0  gio-unix-2.0`
 LDFLAGS +=`pkg-config --libs glib-2.0 gio-unix-2.0`
 
-
 labwc-menu-gnome3: labwc-menu-gnome3.o
 labwc-menu-gnome3: CFLAGS += -DGMENU_I_KNOW_THIS_IS_UNSTABLE
 labwc-menu-gnome3: CFLAGS += `pkg-config --cflags libgnome-menu-3.0`
 labwc-menu-gnome3: LDFLAGS += `pkg-config --libs libgnome-menu-3.0`
 labwc-menu-gnome3.c:
 	cp labwc-menu.c labwc-menu-gnome3.c
+
+labwc-menu-cinnamon: labwc-menu-cinnamon.o
+labwc-menu-cinnamon: CFLAGS += -DGMENU_I_KNOW_THIS_IS_UNSTABLE
+labwc-menu-cinnamon: CFLAGS += `pkg-config --cflags libcinnamon-menu-3.0`
+labwc-menu-cinnamon: LDFLAGS += `pkg-config --libs libcinnamon-menu-3.0`
+labwc-menu-cinnamon.c:
+	cp labwc-menu.c labwc-menu-cinnamon.c
 
 labwc-menu-mate: labwc-menu-mate.o
 labwc-menu-mate: CFLAGS += -DMATEMENU_I_KNOW_THIS_IS_UNSTABLE
@@ -22,5 +28,7 @@ clean:
 	rm -f *.o \
 		labwc-menu-mate \
 		labwc-menu-gnome3 \
+		labwc-menu-cinnamon \
 		labwc-menu-mate.c \
-		labwc-menu-gnome3.c
+		labwc-menu-gnome3.c \
+		labwc-menu-cinnamon.c

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Build
 
 Build for gnome3 menu: `make labwc-menu-gnome3` or just `make`  
-Build for mate menu: `make labwc-menu-mate`
+Build for mate menu: `make labwc-menu-mate`  
+Build for cinnamon menu: `make labwc-menu-cinnamon`
 
 ## Usage
 


### PR DESCRIPTION
`libcinnamon-menu-3-0` is actually API compatible with `libgnome-menu-3-0` so lets add it as well.