### PR TITLE
Make g_string_replace optional

### DIFF
--- a/labwc-menu.c
+++ b/labwc-menu.c
@@ -20,7 +20,11 @@ process_entry(GMenuTreeEntry *entry)
 	}
 
 	GString *name = g_string_new(g_app_info_get_name(G_APP_INFO(info)));
+#if GLIB_CHECK_VERSION(2, 68, 0)
 	g_string_replace(name, "&", "&amp;", 0);
+#else
+	#warning GLIB version < 2.68.0. Run sed -i 's/&/&amp;/g' on resulting menu.xml file
+#endif
 
 	/*
 	 * g_app_info_get_executable() appears not to return any % fields, so


### PR DESCRIPTION
This fixes compilation on non rolling release distros like Debian which currently ships GLib 2.66.8 in its Stable branch.
g_string_replace was added in GLib 2.68.0.

I thought about backporting / reimplementing that function in those cases but it really seemed not worth the hassle.